### PR TITLE
Prevent operation specs unintentionally passing

### DIFF
--- a/spec/sinatra_dynamic_routes_lab_spec.rb
+++ b/spec/sinatra_dynamic_routes_lab_spec.rb
@@ -60,21 +60,25 @@ describe App do
 
     it 'adds two numbers together' do 
       get '/add/10/9'
+      expect(last_response.status).to eq(200)
       expect(last_response.body).to include("19")
     end
 
     it 'subtracts the second number from the first' do 
       get '/subtract/20/9'
+      expect(last_response.status).to eq(200)
       expect(last_response.body).to include("11")
     end
 
     it 'multiplies two numbers together' do 
       get '/multiply/12/11'
+      expect(last_response.status).to eq(200)
       expect(last_response.body).to include("132")
     end
 
     it 'divides the first number by the second number' do 
       get '/divide/10/2'
+      expect(last_response.status).to eq(200)
       expect(last_response.body).to include("5")
     end
   end


### PR DESCRIPTION
The final set of specs for 'GET /:operation/:number1/:number2' do not
include a test for a correct response status.  Without this test if the
error page has any of the numbers that are the expected result of the
operations the tests will pass.

Adding 'expect(last_response.status).to eq(200)' to each of the specs
prevents this error.

This fixes issue #10.
